### PR TITLE
Pin author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: utPins
 Title: What the Package Does (One Line, Title Case)
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# utPins 0.2.1
+
+* Add an optional `pin_author` argument to `publish()` and `publish_all()` so that one Connect
+  account can write a pin to another Connect account (if they have permission on the Connect
+  server).
+
 # utPins 0.2.0
 
 * Strip out server names, business logic and other private content from {utPins}

--- a/R/map-pins.R
+++ b/R/map-pins.R
@@ -20,6 +20,9 @@ prepare_all <- function(pinnables) {
 #'
 #' @param   pinnables   A list of 'pinnable' objects
 #' @param   pin_board   A {pins} board where the pins should be written
+#' @param   pin_author   The name of the author of this pin, may differ from the name of the
+#'   connect-account used to access the Connect board. Assumed identical for all pins (if it isn't,
+#'   add the pin-author name to the "name" argument in `pinnable()`).
 #'
 #' @return   A list of two lists. The "result" entry contains all pins whose data was successfully
 #' pinned to the pin board. The "error" entry contains those pins which failed during the pin
@@ -27,11 +30,12 @@ prepare_all <- function(pinnables) {
 #'
 #' @export
 
-publish_all <- function(pinnables, pin_board) {
+publish_all <- function(pinnables, pin_board, pin_author = NULL) {
   purrr::map(
     pinnables,
     purrr::safely(publish),
-    pin_board = pin_board
+    pin_board = pin_board,
+    pin_author = pin_author
   ) %>%
     partition_successes()
 }

--- a/R/pinnable.R
+++ b/R/pinnable.R
@@ -99,17 +99,25 @@ publish.default <- function(x, ...) {
 #' @param   x   A `pinnable` object.
 #' @param   pin_board   A {pins} board object. This defines the location where the pin will be
 #'   written.
+#' @param   pin_author   The name of the author of this pin, may differ from the name of the
+#'   connect-account used to access the Connect board.
 #' @param   ...   Other parameters. Unused here.
 #'
 #' @export
 
-publish.pinnable <- function(x, pin_board, ...) {
+publish.pinnable <- function(x, pin_board, pin_author = NULL, ...) {
   assert_publishable(x)
+
+  pin_name <- if (!is.null(pin_author)) {
+    paste0(pin_author, "/", x$pin_name)
+  } else {
+    x$pin_name
+  }
 
   pin_path <- pins::pin_write(
     board = pin_board,
     x = x$data,
-    name = x$pin_name,
+    name = pin_name,
     type = x$pin_type
   )
 
@@ -123,13 +131,13 @@ publish.pinnable <- function(x, pin_board, ...) {
 #'
 #' @export
 
-publish.verbose_pinnable <- function(x, pin_board, ...) {
+publish.verbose_pinnable <- function(x, pin_board, pin_author = NULL, ...) {
   httr::with_verbose(
     data_out = TRUE,
     data_in = TRUE,
     info = TRUE,
     ssl = TRUE,
-    expr = publish.pinnable(x, pin_board)
+    expr = publish.pinnable(x, pin_board, pin_author = pin_author, ...)
   )
 }
 

--- a/man/publish.pinnable.Rd
+++ b/man/publish.pinnable.Rd
@@ -4,13 +4,16 @@
 \alias{publish.pinnable}
 \title{\code{publish()} method for pinnable objects}
 \usage{
-\method{publish}{pinnable}(x, pin_board, ...)
+\method{publish}{pinnable}(x, pin_board, pin_author = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{pinnable} object.}
 
 \item{pin_board}{A {pins} board object. This defines the location where the pin will be
 written.}
+
+\item{pin_author}{The name of the author of this pin, may differ from the name of the
+connect-account used to access the Connect board.}
 
 \item{...}{Other parameters. Unused here.}
 }

--- a/man/publish.verbose_pinnable.Rd
+++ b/man/publish.verbose_pinnable.Rd
@@ -4,13 +4,16 @@
 \alias{publish.verbose_pinnable}
 \title{publish() method for verbose-pinnable objects}
 \usage{
-\method{publish}{verbose_pinnable}(x, pin_board, ...)
+\method{publish}{verbose_pinnable}(x, pin_board, pin_author = NULL, ...)
 }
 \arguments{
 \item{x}{A \code{pinnable} object.}
 
 \item{pin_board}{A {pins} board object. This defines the location where the pin will be
 written.}
+
+\item{pin_author}{The name of the author of this pin, may differ from the name of the
+connect-account used to access the Connect board.}
 
 \item{...}{Other parameters. Unused here.}
 }

--- a/man/publish_all.Rd
+++ b/man/publish_all.Rd
@@ -4,12 +4,16 @@
 \alias{publish_all}
 \title{Call 'publish' on each of a list of 'pinnable' objects}
 \usage{
-publish_all(pinnables, pin_board)
+publish_all(pinnables, pin_board, pin_author = NULL)
 }
 \arguments{
 \item{pinnables}{A list of 'pinnable' objects}
 
 \item{pin_board}{A {pins} board where the pins should be written}
+
+\item{pin_author}{The name of the author of this pin, may differ from the name of the
+connect-account used to access the Connect board. Assumed identical for all pins (if it isn't,
+add the pin-author name to the "name" argument in \code{pinnable()}).}
 }
 \value{
 A list of two lists. The "result" entry contains all pins whose data was successfully

--- a/tests/testthat/test-pinnable.R
+++ b/tests/testthat/test-pinnable.R
@@ -67,6 +67,26 @@ describe("publish(pinnable)", {
       )
       expect_equal(stored_numbers, prepared_pin$data)
     })
+    it("writes to pin_author/pin_name if pin_author is provided", {
+      pin_author <- "my_username"
+      published_pin_name <- paste0(pin_author, "/", pin_name)
+      
+      mock_writer <- mockery::mock(TRUE)
+      mockery::stub(publish.pinnable, "pins::pin_write", mock_writer)
+      author_specific_pin <- publish(prepared_pin, pin_board, pin_author = pin_author)
+      
+      # We can't use author/name pins on a pins::board_temp, so we have to catch the arguments to
+      # pin_write instead.
+      # We just want to ensure that name == published_pin_name == pin_author/pin_name
+      mockery::expect_args(
+        mock_writer,
+        1,
+        board = pin_board,
+        x = prepared_pin$data,
+        name = published_pin_name,
+        type = prepared_pin$pin_type
+      )
+    })
   })
 
   it("throws an error if 'data' does not exist", {


### PR DESCRIPTION
When `publish()`ing a pinnable (writing to a pin-board) it would be useful to specify the username of the account that owns the pin. This would allow user-a to update a pin on user-b's account. This can be done by prepending the pin-author/pin-owner's account name before the pin-name (`user-name/pin-name`).

If specified, the pin author's name is prepended during the publish() step (rather than when defining the pinnables). This means there's only one place to change if you want to publish multiple pins to the same author account.